### PR TITLE
Bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,12 @@
 language: generic
 
 os: osx
-osx_image: beta-xcode6.1
+osx_image: xcode6.4
 
 env:
   matrix:
     
     - CONDA_PY=27
-    - CONDA_PY=34
     - CONDA_PY=35
     - CONDA_PY=36
   global:
@@ -20,7 +19,7 @@ env:
 
 before_install:
     # Remove homebrew.
-    - brew remove --force $(brew list)
+    - brew remove --force --ignore-dependencies $(brew list)
     - brew cleanup -s
     - rm -rf $(brew --cache)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,14 +23,6 @@ environment:
       CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
-      CONDA_PY: 34
-      CONDA_INSTALL_LOCN: C:\\Miniconda3
-
-    - TARGET_ARCH: x64
-      CONDA_PY: 34
-      CONDA_INSTALL_LOCN: C:\\Miniconda3-x64
-
-    - TARGET_ARCH: x86
       CONDA_PY: 35
       CONDA_INSTALL_LOCN: C:\\Miniconda35
 
@@ -40,11 +32,11 @@ environment:
 
     - TARGET_ARCH: x86
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
 
     - TARGET_ARCH: x64
       CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions
@@ -67,9 +59,8 @@ install:
     - cmd: rmdir C:\cygwin /s /q
 
     # Add path, activate `conda` and update conda.
-    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
-    - cmd: conda update --yes --quiet conda
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
+    - cmd: conda update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1
 

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,15 +41,9 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 4 case(s).
+# Embarking on 3 case(s).
     set -x
     export CONDA_PY=27
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_PY=34
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.0.2" %}
+{% set version = "1.0.3" %}
 
 package:
   name: cc-plugin-glider
@@ -7,7 +7,7 @@ package:
 source:
   fn: cc-plugin-glider-{{ version }}.tar.gz
   url: https://github.com/ioos/cc-plugin-glider/archive/{{ version }}.tar.gz
-  sha256: 17c8fd7df37821458b9633849a42db5c8c8c8b6bb46c6be712a043995299c28c
+  sha256: 66784b75ad3afe72f7e4592d7b77ff1ba58a8d7a466f421c2ffe7141a5faae99
 
 build:
   number: 0


### PR DESCRIPTION
```
With this release we moved all the netCDF files out of the repository in favor of CDL files, like with the main-project and other plugins. We also integrated checker support for the changes in the new v3.0 format:

- `ioos_regional_association` global attribute
- optional QARTOD variables

In addition to these new changes, we added some checks for some common errors we've seen with submissions:

- `valid_min` `valid_max` variable attributes having a mismatched data type
- `valid_min` `valid_max` for longitude being set to [-90, 90]
```

Closes https://github.com/ioos/cc-plugin-glider/issues/13

Ping @lukecampbell